### PR TITLE
Allow argument to Torrent to be a file-like / bytes object or a file path

### DIFF
--- a/aiotorrent/aiotorrent.py
+++ b/aiotorrent/aiotorrent.py
@@ -27,9 +27,13 @@ logger.addHandler(logging.NullHandler())
 
 class Torrent:
 	def __init__(self, torrent_file):
-		torrent = open(torrent_file, 'rb')
-		bencoded_data = torrent.read()
-		torrent.close()
+		if isinstance(torrent_file, bytes):
+			bencoded_data = torrent_file
+		elif hasattr(torrent_file, 'read'):
+			bencoded_data = torrent.read()
+		else:
+			with open(torrent_file, 'rb') as torrent:
+				bencoded_data = torrent.read()
 
 		# dict_keys(['files', 'name', 'piece length', 'pieces'])
 		data = bencode.bdecode(bencoded_data)


### PR DESCRIPTION
This allows torrent data to not be persistent on disk. For instance, a program using aiotorrent downloads the torrent from a url, but does not want to persist it to disk. Or say a bunch of torrents are stored in a zip file on disk.