### PR TITLE
Sequential downloading fixes

### DIFF
--- a/aiotorrent/downloader.py
+++ b/aiotorrent/downloader.py
@@ -120,7 +120,6 @@ class FilesDownloadManager:
 					if not task.done():
 						break
 					else:
-						task_list.remove(task)
 						piece = task.result()
 						file._set_bytes_downloaded(file.get_bytes_downloaded() + len(piece.data))
 						# yield piece


### PR DESCRIPTION
I ran across a couple bugs in the sequential downloader that leads me to believe that it basically never worked for multi-piece files and perhaps even never at all because of the bug fixed in the first commit.

The first commit fixes an issue where `get_file_sequential` was returning before all the `Piece.download` tasks were finshed running. In my case, before any finished.

The second commit is an issue with dropping piece data because a list was being modified from within the body of a for loop that was iterating over it. To see what is effectively being done, here's an essentialized example, notice how not all the items of the list are run with the body of the for loop:
```
>>> l = [1,2,3,4,5]
>>> for i in l:
...     print(i)
...     l.remove(i)
...     
1
3
5
```

The funny thing is that the list manipulation is completely unnecessary because `task_list` is never used after iterating through it.