### PR TITLE
Add missing updates to switch from fast-bencode to fastbencode

### DIFF
--- a/aiotorrent/core/trackers.py
+++ b/aiotorrent/core/trackers.py
@@ -2,7 +2,6 @@ import asyncio
 import logging
 from random import randint
 from typing import Literal
-from bencode import bdecode
 from socket import gaierror
 from struct import pack, unpack
 from ipaddress import IPv4Address
@@ -10,6 +9,7 @@ from http.client import HTTPConnection, HTTPSConnection
 from urllib.parse import urlparse, urlencode, ParseResult
 
 from aiotorrent.core.util import chunk
+from aiotorrent.core.bencode_utils import bencode_util
 
 
 logger = logging.getLogger(__name__)
@@ -298,7 +298,7 @@ class HTTPTracker(TrackerBaseClass):
 
 			if response.status == 200:
 				self.active = True
-				self.announce_response = bdecode(response.read())
+				self.announce_response = bencode_util.bdecode(response.read())
 				peer_list = self.announce_response['peers']
 				for ip_addr in chunk(peer_list, 6):
 					ip, port = unpack('>IH', ip_addr)

--- a/aiotorrent/core/trackers.py
+++ b/aiotorrent/core/trackers.py
@@ -201,7 +201,7 @@ class UDPTracker(TrackerBaseClass):
 	class UDPProtocolFactory(asyncio.DatagramProtocol):
 		# Missing typehint
 		def __init__(self, parent_obj):
-			self.transport: None | asyncio.DatagramProtocol = None
+			self.transport: None | asyncio.DatagramTransport = None
 			self.address = (parent_obj.hostname, parent_obj.port)
 			self.parent_obj = parent_obj
 


### PR DESCRIPTION
The recent commit for `v0.9.1` (6e99d3264494b), did not update all places where `bencode` was imported.